### PR TITLE
Fix docker network on ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # video-shop
+<p>Log in to admin's account with password: <code>Admin12345</code></p>
 <h3>Backend</h3>
 <p>
 In order to run backend as a standalone, go to <code>service</code> and run:<br>
 <code>docker-compose up</code>
+<br>Then start app with active <code>dev</code> profile.
 </p>
-<p>
-
-<p>Log in to admin's account with password: <code>Admin12345</code></p>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,8 @@ services:
     ports:
       - 8080:8080
     restart: on-failure
-    network_mode: host
+    networks:
+      - video-network
 
   webclient:
     container_name: webclient

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,8 +28,7 @@ services:
     ports:
       - 8080:8080
     restart: on-failure
-    networks:
-      - video-network
+    network_mode: host
 
   webclient:
     container_name: webclient

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.6.3-jdk-11-slim AS build
 COPY /src /usr/src/spring/src
 COPY pom.xml /usr/src/spring
 COPY Dockerfile /usr/src/spring
-RUN mvn -f /usr/src/spring/pom.xml clean install
+RUN mvn -f /usr/src/spring/pom.xml -DskipTests=true clean install
 
 FROM openjdk:11-jre-slim
 RUN apt-get update

--- a/service/src/main/resources/application-dev.yml
+++ b/service/src/main/resources/application-dev.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/videostore
+
+  flyway:
+    url: jdbc:postgresql://localhost:5432/videostore

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/videostore
+    url: jdbc:postgresql://postgres:5432/videostore
     username: postgres
     password: postgres
   jpa:
@@ -13,7 +13,7 @@ spring:
   flyway:
     enabled: true
     validate-on-migrate: true
-    url: jdbc:postgresql://localhost:5432/videostore
+    url: jdbc:postgresql://postgres:5432/videostore
     user: postgres
     password: postgres
     locations: classpath:db/migration


### PR DESCRIPTION
Workaround for datasource connection problem on ubuntu. 

afair, you use MacOS, am I right? So I'm pretty sure you didn't have any problems with that, but I couldn't run whole app, because flyways failed (could not connect to `localhost:5432`)

After my change, I've checked if frontend is still properly connected to backend and tested login and registration forms and everything seemed to be okay

I also skipped tests for building a docker image of `videostore`